### PR TITLE
FIX: use get_target_matches to get today_utc

### DIFF
--- a/db_manage.py
+++ b/db_manage.py
@@ -1,7 +1,7 @@
 from models import User, Evaluation
 from app import db
 from datetime import datetime, timedelta
-from pytz import timezone
+from pytz import timezone, utc
 
 
 def create_user(form):
@@ -102,14 +102,24 @@ def get_user_record(form):
     return user_record
 
 
+def get_today_start_dt():
+    """
+    get today's 00:00:00 KST datetime and convert it to UTC datetime
+    :return datetime: today's 00:00:00 datetime(UTC)
+    """
+    now_dt_kst = datetime.now(timezone('Asia/Seoul'))
+    today_start_dt_kst = now_dt_kst.replace(hour=00, minute=00, second=00)
+    today_start_dt_utc = today_start_dt_kst.astimezone(utc)
+    return today_start_dt_utc
+
+
 def get_user_current_mate(user):
     """
     get today's mate by getting evaluation record based on current day
     :param user: User
     :return string or none: today's mate if exists
     """
-    today_kst = datetime.now(timezone('Asia/Seoul'))
-    today_utc = datetime.combine(today_kst.date(), datetime.min.time())
+    today_utc = get_today_start_dt()
     yesterday_utc = today_utc - timedelta(days=1)
     current_evaluation = Evaluation.query.filter(Evaluation.user == user).order_by(Evaluation.index.desc()).first()
     if current_evaluation is None:

--- a/models.py
+++ b/models.py
@@ -42,7 +42,7 @@ class Match(db.Model):
     __tablename__ = 'matches'
 
     index = db.Column(db.Integer, primary_key=True)
-    match_day = db.Column(db.DateTime(timezone=True), default=datetime.utcnow)
+    match_day = db.Column(db.DateTime(timezone=True), default=datetime.utcnow())
     users = db.relationship(User, secondary=user_identifier, backref='matches')
     activity_index = db.Column(db.Integer, db.ForeignKey('activities.index'))
     activity = db.relationship("Activity")

--- a/send_evaluation_schedule_functions.py
+++ b/send_evaluation_schedule_functions.py
@@ -2,19 +2,8 @@ from app import db, slack
 from blocks import get_evaluation_blocks
 from models import Match
 import json
-from datetime import datetime, timedelta
-from pytz import timezone, utc
-
-
-def get_today_start_dt():
-    """
-    get today's 00:00:00 KST datetime and convert it to UTC datetime
-    :return datetime: today's 00:00:00 datetime(UTC)
-    """
-    now_dt_kst = datetime.now(timezone('Asia/Seoul'))
-    today_start_dt_kst = now_dt_kst.replace(hour=00, minute=00, second=00)
-    today_start_dt_utc = today_start_dt_kst.astimezone(utc)
-    return today_start_dt_utc
+from datetime import timedelta
+from db_manage import get_today_start_dt
 
 
 def get_target_matches():


### PR DESCRIPTION
-  /42mate 커맨드 입력시 "typeError: can't compare offset-naive and offset-aware datetimes" 에러가 발생하여 원인을 파악하였습니다.
- get_user_current_mate 에서 today_utc를 구할 때 timezone info가 입력되지 않아서 생긴 오류인 것을 확인하였습니다.
- get_today_start_dt() 함수 활용하여 today_utc에 timezone info를 포함시켜 해결했습니다.
- 이 과정에서 send_evaluation_schedule.py파일 내에 선언되어있던 get_today_start_dt() 함수를 db_manage.py 파일로 이동시켰습니다. 더 적절한 위치가 있을 수 있으니 확인부탁드립니다~!