### PR TITLE
FIX: typo

### DIFF
--- a/models.py
+++ b/models.py
@@ -42,7 +42,7 @@ class Match(db.Model):
     __tablename__ = 'matches'
 
     index = db.Column(db.Integer, primary_key=True)
-    match_day = db.Column(db.DateTime(timezone=True), default=datetime.utcnow())
+    match_day = db.Column(db.DateTime(timezone=True), default=datetime.utcnow)
     users = db.relationship(User, secondary=user_identifier, backref='matches')
     activity_index = db.Column(db.Integer, db.ForeignKey('activities.index'))
     activity = db.relationship("Activity")


### PR DESCRIPTION
- Models 테이블 생성시 초기화값으로 utcnow가 아닌 utcnow()가 들어간 오타를 바로 잡습니다.